### PR TITLE
Set up printf to dynamically change loop length, etc 

### DIFF
--- a/holberton.h
+++ b/holberton.h
@@ -20,7 +20,7 @@ typedef struct specifier
 	char type;
 } spec;
 
-spec *get_specs(void);
+spec *get_specs(unsigned int *);
 void print_number(int n);
 int _pow(int a, int b);
 int getnum(int num, int index);

--- a/printf.c
+++ b/printf.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include "holberton.h"
@@ -14,10 +15,11 @@ int _printf(const char *string, ...)
 	va_list *valist;
 	spec *specs;
 	int count = 0, flag = 0;
+	unsigned int specnum = 0;
 
 	valist = malloc(sizeof(va_list));
-	specs = get_specs();
-	if (valist == NULL || specs == NULL)
+	specs = get_specs(&specnum);
+	if (string == NULL || valist == NULL || specs == NULL)
 		return (-1);
 	va_start(*valist, string);
 	for (i = 0; string[i]; i++)
@@ -32,7 +34,7 @@ int _printf(const char *string, ...)
 				flag = 1;
 			}
 
-			for (k = 0; k < 4 && flag == 0; k++)
+			for (k = 0; k < specnum && flag == 0; k++)
 			{
 				if (*(specs[k].spec_string) == string[i + 1])
 				{
@@ -54,24 +56,27 @@ int _printf(const char *string, ...)
  * spec structs
  * Return: Pointer to the first element in an array of `spec`s
  */
-spec *get_specs(void)
+spec *get_specs(unsigned int *i)
 {
-	const int num = 4;
-	int i;
-	spec *ret_spec = malloc(sizeof(spec) * num);
-
-	if (ret_spec == NULL)
-		return (NULL);
-
+	spec *ret_spec;
+	unsigned int j;	
 	spec specs[] = {
 		{"i", print_decimal, 'i'},
 		{"d", print_decimal, 'i'},
 		{"s", print_string, 's'},
-		{"c", print_char, 'i'}
+		{"c", print_char, 'i'},
+		{NULL, NULL, '\0'}
 	};
 
-	for (i = 0; i < num; i++)
-		ret_spec[i] = specs[i];
+	for (; specs[*i].spec_string != NULL; (*i)++)
+		;
+
+	ret_spec = malloc(sizeof(spec) * (*i));
+	if (ret_spec == NULL)
+		return (NULL);
+
+	for (j = 0; j < *i; j++)
+		ret_spec[j] = specs[j];
 
 	return (ret_spec);
 }

--- a/printf.c
+++ b/printf.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
 #include "holberton.h"
@@ -6,6 +5,7 @@
 /**
  * _printf - prints data to standard out
  * @string: Char string that will include specifiers
+ *
  * Return: the number of characters printed.
  */
 int _printf(const char *string, ...)
@@ -54,12 +54,15 @@ int _printf(const char *string, ...)
 /**
  * get_specs - Gives a pointer to allocated space containing all predefined
  * spec structs
+ * @i: Pointer to an unsigned int which will be iterated based on how many
+ * spec strucs will be returnes
+ *
  * Return: Pointer to the first element in an array of `spec`s
  */
 spec *get_specs(unsigned int *i)
 {
 	spec *ret_spec;
-	unsigned int j;	
+	unsigned int j;
 	spec specs[] = {
 		{"i", print_decimal, 'i'},
 		{"d", print_decimal, 'i'},


### PR DESCRIPTION
Set up printf to dynamically change loop length, etc based off of number of structures in an array by using a null struct at the end of the array.

This setup uses a structure full of NULL information to signal the end of the array. Now, the `get_specs` function takes a pointer to an `unsigned int` which it will change to the length of the array of structs defined within itself, not including the NULL struct.

This pointer comes from the `_printf` function which has an `unsigned int` variable `specnum` which is used as the limit for the loop which loops through all specifiers.

Also added a check to see if `string` is NULL.